### PR TITLE
feat: support typ 111 in nix log parser

### DIFF
--- a/cmds/install-secrets/src/main.rs
+++ b/cmds/install-secrets/src/main.rs
@@ -200,7 +200,7 @@ fn install(data: &Path) -> anyhow::Result<()> {
 
 	if data.is_empty() {
 		info!("no secrets to install");
-		return Ok(())
+		return Ok(());
 	}
 
 	let identity = host_identity()?;


### PR DESCRIPTION
# Description

This adds support for logs with `typ: 111` which are known to be warnings.

Closes #10